### PR TITLE
Fix #17

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@ Any other information you want to share that is relevant to the issue being repo
 
 ```text
 DistractionFreeWindow:
-    release:        0.6.1
+    release:        0.6.2
 
 Sublime Text:
     channel:        stable / dev

--- a/distraction_free_window.py
+++ b/distraction_free_window.py
@@ -188,7 +188,7 @@ class DistractionFreeWindowCommand(sublime_plugin.WindowCommand):
                     return (state1_w < state2_w)
 
     def is_menu_visible(self):
-        if ST3098:
+        if ST3116:
             return self.window.is_menu_visible()
         else:
             if ST3:

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,3 @@
 {
-    "0.6.1": "messages/latest.md"
+    "0.6.2": "messages/latest.md"
 }

--- a/messages/latest.md
+++ b/messages/latest.md
@@ -1,12 +1,6 @@
-DistractionFreeWindow (0.6.1)
+DistractionFreeWindow (0.6.2)
 =============================
 
-* DistractionFreeWindow now also hides the menu by default when
-  DFW mode is enabled. You can change this in your user settings.
-* Further enhanced readability of the README by getting rid of
-  the table of contents, changing the screencast description and
-  updating the docs with new changes to version `0.6`.
-* Issue #6 has finally been fixed, sincere apologies to effected
-  users! It caused undesired behaviour when switching views within
-  a window after having enabled DFW mode and then trying to leave
-  it again back to normal mode.
+* DistractionFreeWindow had a small regression where it was trying
+  to find out whether or not the menu was shown on Builds before
+  3116, which is fixed now.


### PR DESCRIPTION
Fix #17 

DistractionFreeWindow had a small regression where it was trying to find out whether or not the menu was shown on Builds before 3116, which is fixed now.